### PR TITLE
Add wordflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Your contributions are always welcome!
 
 ## Inference UI
 
+- [Wordflow](https://github.com/poloclub/wordflow) - Run, share, and discover AI prompts in your browsers
 - [oobabooga](https://github.com/oobabooga/text-generation-webui) - A Gradio web UI for Large Language Models
 - [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs.
 - [LocalAI](https://github.com/go-skynet/LocalAI) - LocalAI is a drop-in replacement REST API that’s compatible with OpenAI API specifications for local inferencing.


### PR DESCRIPTION
Thanks for the great list! This PR adds [Wordflow](https://github.com/poloclub/wordflow) to the Inference UI. Wordflow allows users to run open-source LLMs (e.g., Gemma, Llama 2, Phi 2) directly in their browsers.