### PR TITLE
Add AI-Mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Your contributions are always welcome!
 - [ComfyUI](https://github.com/comfyanonymous/ComfyUI) - A powerful and modular stable diffusion GUI with a graph/nodes interface.
 - [petals](https://github.com/bigscience-workshop/petals) - Run LLMs at home, BitTorrent-style. Fine-tuning and inference up to 10x faster than offloading
 - [ChatUI](https://github.com/huggingface/chat-ui) - Open source codebase powering the HuggingChat app
+- [AI-Mask](https://github.com/pacoccino/ai-mask) - Browser extension to provide model inference to web apps. Backed by web-llm and transformers.js
 
 
 ## Platforms / full solutions


### PR DESCRIPTION
https://github.com/pacoccino/ai-mask

AI-Mask is a chrome web extension that serves as a local provider to AI models execution. It runs model on-device for web apps which needs it, for free, and with full-privacy.