### PR TITLE
Add Knovex to Inference UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Your contributions are always welcome!
 - [FireworksAI](https://app.fireworks.ai/) - Experience the world's fastest LLM inference platform deploy your own at no additional cost.
 - [faradav](https://faraday.dev/) - Chat with AI Characters Offline, Runs locally, Zero-configuration.
 - [GPT4All](https://gpt4all.io) - A free-to-use, locally running, privacy-aware chatbot.
+- [Knovex](https://github.com/tailorgunjan93/knovex) - Local-first AI knowledge base. Chat with your documents, semantic search, summaries and a gamified Learn Mode. Works fully offline with Ollama or any OpenAI-compatible API.
 - [LLMFarm](https://github.com/guinmoon/LLMFarm) - llama and other large language models on iOS and MacOS offline using GGML library.
 - [LlamaChat](https://llamachat.app/) - LlamaChat allows you to chat with LLaMa, Alpaca and GPT4All models1 all running locally on your Mac.
 - [LLM as a Chatbot Service](https://github.com/deep-diver/LLM-As-Chatbot) - LLM as a Chatbot Service.


### PR DESCRIPTION
Adds **Knovex** to the Inference UI section.

Knovex is a free, open-source, local-first AI knowledge base for desktop (Windows/macOS/Linux). It lets you chat with your documents (PDF, DOCX, XLSX, Markdown) with cited sources, run hybrid semantic + full-text search, generate summaries, and use a gamified "Learn Mode" (quizzes, flashcards, mind maps). It runs fully offline with Ollama, or works with any OpenAI-compatible provider (OpenAI, Anthropic, Groq, Gemini). MIT licensed.

Repo: https://github.com/tailorgunjan93/knovex